### PR TITLE
Fix for renamed manager directory

### DIFF
--- a/assets/lib/multidomain/check_index.php
+++ b/assets/lib/multidomain/check_index.php
@@ -102,9 +102,10 @@ ExtendIndexFile(array(
                      "\$modx->getSites();"
 ));
 
+require(MODX_BASE_PATH.'assets/cache/siteManager.php');
 ExtendIndexFile(array(
-  'index_path'    => 'manager/',
-  'version_file'  => 'assets/files/.manager_index.php.md5',
+  'index_path'    =>  MGR_DIR.'/',
+  'version_file'  => 'assets/files/.'.MGR_DIR.'_index.php.md5',
   
   'search'        => "\$modx = new DocumentParser;\n".
                      "\$modx->loadExtension(\"ManagerAPI\");\n".

--- a/assets/lib/multidomain/check_index.php
+++ b/assets/lib/multidomain/check_index.php
@@ -105,7 +105,7 @@ ExtendIndexFile(array(
 require(MODX_BASE_PATH.'assets/cache/siteManager.php');
 ExtendIndexFile(array(
   'index_path'    =>  MGR_DIR.'/',
-  'version_file'  => 'assets/files/.'.MGR_DIR.'_index.php.md5',
+  'version_file'  => 'assets/files/.manager_index.php.md5',
   
   'search'        => "\$modx = new DocumentParser;\n".
                      "\$modx->loadExtension(\"ManagerAPI\");\n".


### PR DESCRIPTION
Quick fix for a renamed manager directory. Otherwise the script always says "cannot find manager/index.php".
But I don't know if the MGR_DIR should be in the version_file name...